### PR TITLE
Add CMake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.1)
 
-project(AltKit LANGUAGES Swift)
+project(AltKit LANGUAGES C Swift)
 
 add_library(CAltKit
     Sources/CAltKit/NSError+ALTServerError.h
@@ -21,6 +21,12 @@ add_library(AltKit
     Sources/AltKit/Types/CodableServerError.swift
 )
 
-target_link_libraries(AltKit PUBLIC CAltKit)
+target_link_libraries(AltKit PRIVATE CAltKit)
 set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Sources/CAltKit")
 set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_VERSION "5.0")
+target_include_directories(AltKit INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(TARGET AltKit
+                   POST_BUILD
+                   COMMAND cp $DERIVED_SOURCES_DIR/AltKit-Swift.h ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,4 @@ add_library(AltKit
 
 target_link_libraries(AltKit PUBLIC CAltKit)
 set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Sources/CAltKit")
+set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_VERSION "5.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.15.1)
+
+project(AltKit LANGUAGES Swift)
+
+add_library(CAltKit
+    Sources/CAltKit/NSError+ALTServerError.h
+    Sources/CAltKit/NSError+ALTServerError.m
+)
+
+add_library(AltKit
+    Sources/AltKit/Extensions/ALTServerError+Conveniences.swift
+    Sources/AltKit/Extensions/Result+Conveniences.swift
+
+    Sources/AltKit/Server/Connection.swift
+    Sources/AltKit/Server/NetworkConnection.swift
+    Sources/AltKit/Server/Server.swift
+    Sources/AltKit/Server/ServerConnection.swift
+    Sources/AltKit/Server/ServerManager.swift
+    Sources/AltKit/Server/ServerProtocol.swift
+
+    Sources/AltKit/Types/CodableServerError.swift
+)
+
+target_link_libraries(AltKit PUBLIC CAltKit)
+set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Sources/CAltKit")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,16 @@ add_library(AltKit
 )
 
 target_link_libraries(AltKit PRIVATE CAltKit)
-set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Sources/CAltKit")
+
 set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_VERSION "5.0")
+
+# Make CAltKit's modulemap available to AltKit
+set_property(TARGET AltKit PROPERTY XCODE_ATTRIBUTE_SWIFT_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Sources/CAltKit")
+
+# Add binary dir to interface include path to make Swift header accessible to targets using AltKit
 target_include_directories(AltKit INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
+# Copy generated Swift header to binary dir
 add_custom_command(TARGET AltKit
                    POST_BUILD
                    COMMAND cp $DERIVED_SOURCES_DIR/AltKit-Swift.h ${CMAKE_CURRENT_BINARY_DIR}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ Finally, right-click on your app's `Info.plist`, select "Open As > Source Code",
 <string>[Your app] uses the local network to find and communicate with AltServer.</string>
 ```
 
+### CMake Integration
+
+Note: CMake 3.15 is required for the integration. The integration only works with the Xcode generator.
+
+Steps:
+- Add the AltKit CMake project to your CMake project using `add_subdirectory`.
+- Add Swift to your project's supported languages. (ex.: `project(projName LANGUAGES C Swift)`)
+
+If you're using `add_compile_options` or `target_compile_options` and the Swift compiler complains about the option not being supported, it's possible to use CMake's generator expressions to limit the options to non-Swift source files.
+
+Example:
+```
+add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fPIC>)
+```
+
 ## Usage
 
 ### Swift

--- a/Sources/CAltKit/module.modulemap
+++ b/Sources/CAltKit/module.modulemap
@@ -1,0 +1,4 @@
+module CAltKit {
+    umbrella "./include"
+    export *
+}


### PR DESCRIPTION
This adds support for integration of AltKit in CMake based projects.

Integration instructions were added in the `README.md` file.