### PR TITLE
Support linking with lower version OS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "AltKit",
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12)
+        .iOS(.v11),
+        .tvOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/AltKit/Server/NetworkConnection.swift
+++ b/Sources/AltKit/Server/NetworkConnection.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Network
 
+@available(iOS 12, tvOS 12, watchOS 5, macOS 10.14, *)
 public class NetworkConnection: NSObject, Connection
 {
     public let nwConnection: NWConnection
@@ -52,10 +53,7 @@ public class NetworkConnection: NSObject, Connection
         default: self.nwConnection.cancel()
         }
     }
-}
-
-extension NetworkConnection
-{
+    
     override public var description: String {
         return "\(self.nwConnection.endpoint) (Network)"
     }

--- a/Sources/AltKit/Server/ServerManager.swift
+++ b/Sources/AltKit/Server/ServerManager.swift
@@ -19,6 +19,7 @@ public enum ConnectionError: LocalizedError
     case connectionFailed(Server)
     case connectionDropped(Server)
     case unknownUDID
+    case unsupportedOS
     
     public var errorDescription: String? {
         switch self
@@ -27,6 +28,7 @@ public enum ConnectionError: LocalizedError
         case .connectionFailed: return NSLocalizedString("Could not connect to AltServer.", comment: "")
         case .connectionDropped: return NSLocalizedString("The connection to AltServer was dropped.", comment: "")
         case .unknownUDID: return NSLocalizedString("This device's UDID could not be determined.", comment: "")
+        case .unsupportedOS: return NSLocalizedString("This device's OS version is too old to run AltKit.", comment: "")
         }
     }
 }
@@ -106,7 +108,10 @@ public extension ServerManager
         }
         
         self.dispatchQueue.async {
-
+            guard #available(iOS 12, tvOS 12, watchOS 5, macOS 10.14, *) else {
+                finish(.failure(ConnectionError.unsupportedOS))
+                return
+            }
             print("Connecting to service:", server.service)
             
             let connection = NWConnection(to: .service(name: server.service.name, type: server.service.type, domain: server.service.domain, interface: nil), using: .tcp)


### PR DESCRIPTION
Swift PM does not have a good way to conditionally include a package. That
means that apps targeting a lower OS version cannot import AltKit. As a
workaround, we lower the linking version while inserting availability
checks into AltKit.

Since NWConnection requires iOS 12, we will return an error when trying to
connect with iOS 11.